### PR TITLE
remove permissions for announcements

### DIFF
--- a/corevolthrm/views.py
+++ b/corevolthrm/views.py
@@ -148,4 +148,4 @@ def logoutUser(request):
 class AnnouncementList(generics.ListCreateAPIView):
     queryset = Announcement.objects.all()
     serializer_class = AnnouncementSerializer
-    permission_classes = [IsAuthenticated]
+    # permission_classes = [IsAuthenticated]


### PR DESCRIPTION
permissions does not work as expected, so removing it in the announcement views for the time being.